### PR TITLE
Added CODEOWNERS for auto adding reviewers

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -1,0 +1,13 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# the following will be requested for
+# review when someone opens a pull request.
+*       @LukeShirnia @dsgnr @LukeHandle
+
+# In this example, @doctocat owns any files in the build/logs
+# directory at the root of the repository and any of its
+# subdirectories.
+postfixbuddy/ @dsgnr

--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -7,7 +7,7 @@
 # review when someone opens a pull request.
 *       @LukeShirnia @dsgnr @LukeHandle
 
-# In this example, @doctocat owns any files in the build/logs
+# The following section assigns reviewers per
 # directory at the root of the repository and any of its
 # subdirectories.
 postfixbuddy/ @dsgnr


### PR DESCRIPTION
Added CODEOWNERS file for automatic adding of reviewers to PRs and specific subrepos:

https://help.github.com/en/articles/about-code-owners