### PR TITLE
Added codeowners for future subrepos

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -10,5 +10,12 @@
 # The following section assigns reviewers per
 # directory at the root of the repository and any of its
 # subdirectories.
-postfixbuddy/ @dsgnr
+postfixbuddy/     @dsgnr
 traffic_analyser/ @dsgnr
+pleskbuddy/       @dsgnr
+php-fpmpal/       @gsgnr
+Low_disk/         @LukeShirnia
+out-of-memory/    @LukeShirnia
+nginxctl/         @LukeShirnia
+ps_mem/           @LukeShirnia
+apache2buddy/     @richardforth


### PR DESCRIPTION
Assigned codeowners to all subrepos that are going to be added to useful-scripts
```
postfixbuddy/     @dsgnr
postfixbuddy/     @dsgnr
traffic_analyser/ @dsgnr
pleskbuddy/       @dsgnr
php-fpmpal/       @gsgnr
disk_usage/       @LukeShirnia
out-of-memory/    @LukeShirnia
nginxctl/         @LukeShirnia
ps_mem/           @LukeShirnia
apache2buddy/     @richardforth
```