### PR TITLE
Exclude test files from being checked

### DIFF
--- a/audit.sh
+++ b/audit.sh
@@ -109,7 +109,7 @@ clone_repo() {
 # Not everything in a subrepo needs to be checksum'd. Only the file being executed
 # This function finds the appropriate file(s) and asks you to select if more than 1 executable file exists
 find_checksum_file() {
-    _files=$(for i in $(find $1 -type d -exec ls '{}' ';' | grep ".sh\|.py\|mysqltuner.pl\|apache2buddy.pl" | grep -v 'setup'); do echo $i; done)
+    _files=$(for i in $(find $1 -type d -exec ls '{}' ';' | grep ".sh\|.py\|mysqltuner.pl\|apache2buddy.pl" | grep -v 'setup\|test'); do echo $i; done)
 
     counter=1
 


### PR DESCRIPTION
This PR excludes "test" files from being selected as potential files to SHA1SUM check. 