### PR TITLE
Fixed small issue with git-subrepo version check

### DIFF
--- a/audit.sh
+++ b/audit.sh
@@ -328,7 +328,7 @@ After git installation please install git subrepo:
 "git subrepo" does not appear to be installed.
 Please install git subrepo:
                 https://github.com/ingydotnet/git-subrepo'
-    elif echo "$version" "0.4.0" | awk '{ exit !($1 > $2)}'; then
+    elif echo "$version" "0.4.0" | awk '{ exit !($1 < $2)}'; then
        error_message '
 "git subrepo" version is too low
 Please update:


### PR DESCRIPTION
Fixed git subrepo version check.
Previously:
```
[lukeshirnia@rax useful-scripts]$ git-subrepo --version
0.4.1
```
```
[lukeshirnia@rax useful-scripts]$ ./audit.sh --help

"git subrepo" version is too low
Please update:
                https://github.com/ingydotnet/git-subrepo
```
Now:
```
[lukeshirnia@rax useful-scripts]$ git-subrepo --version
0.4.1
```
```
[lukeshirnia@rax useful-scripts]$ ./audit.sh --help
Usage: ./audit.sh [options]
          -a, --add     <reponame> <url>   Specify name of new repo
          -a, --add     <reponame> <url> -b <release>
                                           Specify name of new repo and a specific release
          -u, --update  <reponame>         Update existing repo
          -c, --check   <reponame>         Check for updates on existing repo
          -v, --verify  <reponame> [local] Verifies local branch (not been pushed to git)

          -h, --help                      Print help (usage)
```

```